### PR TITLE
Pulls PR-branch only instead of adding new remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,52 +43,60 @@ octo-merge \
 
 ## Available Strategies
 
+* NOTE: All strategies are using read-only branches for a specific pull requests.
+        This way we avoid adding lot of remotes.
+* Read more: [Checking out pull requests locally](https://help.github.com/articles/checking-out-pull-requests-locally/)
+
 ### MergeWithoutRebase
 
-```ruby
-git.checkout(master)
-git.fetch(upstream)
-git.reset_hard("#{upstream}/#{master}")
+```
+# Reset master
+git checkout master
+git fetch upstream
+git reset --hard upstream/master
 
-pull_requests.each do |pull_request|
-  git.remote_add("#{pull_request.remote} #{pull_request.remote_url}")
-  git.fetch(pull_request.remote)
-  git.merge_no_ff("#{pull_request.remote}/#{pull_request.branch}")
-end
+# For each pull request
+  git fetch upstream pull/23/head:pull/23 --force"
+  git merge --no-ff pull/23
+  git branch -D pull/23
 ```
 
 ### MergeWithRebase
 
-```ruby
-git.checkout(master)
-git.fetch(upstream)
-git.reset_hard("#{upstream}/#{master}")
+```
+# Reset master
+git checkout master
+git fetch upstream
+git reset --hard upstream/master
 
-pull_requests.each do |pull_request|
-  git.remote_add("#{pull_request.remote} #{pull_request.remote_url}")
-  git.fetch(pull_request.remote)
-  git.checkout(pull_request.branch)
-  git.rebase(master)
-  git.checkout(master)
-  git.merge_no_ff(pull_request.branch)
-end
+# For each pull request
+  git fetch upstream pull/23/head:pull/23 --force"
+  git checkout pull/23
+  git rebase master
+
+  git checkout master
+  git merge --no-ff pull/23
+
+  git branch -D pull/23
 ```
 
 ### Rebase
 
-```ruby
-git.checkout(master)
-git.fetch(upstream)
-git.reset_hard("#{upstream}/#{master}")
+```
+# Reset master
+git checkout master
+git fetch upstream
+git reset --hard upstream/master
 
-pull_requests.each do |pull_request|
-  git.remote_add("#{pull_request.remote} #{pull_request.remote_url}")
-  git.fetch(pull_request.remote)
-  git.checkout(pull_request.branch)
-  git.rebase(master)
-  git.checkout(master)
-  git.rebase("#{pull_request.branch}")
-end
+# For each pull request
+  git fetch upstream pull/23/head:pull/23 --force"
+  git checkout pull/23
+  git rebase master
+
+  git checkout master
+  git rebase pull/23
+
+  git branch -D pull/23
 ```
 
 ## Development

--- a/TODO.md
+++ b/TODO.md
@@ -8,4 +8,4 @@ Before we release `v1.0.0` the following tasks needs to be done:
 * [ ] Complete docs (`README.md`)
 * [ ] Try to get rid of external dependencies (`octokit`, `inquirer`)
 * [ ] Decide on gem name (`octo_merge` VS `octo-merge`)
-* [ ] Use GitHubs `secret` pull requests branches instead of adding new remotes
+* [x] Use GitHubs `secret` pull requests branches instead of adding new remotes

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -28,6 +28,7 @@ class Git
 
   git :checkout
   git :commit
+  git :delete_branch, "branch -D"
   git :fetch
   git :merge_no_ff, "merge --no-ff"
   git :rebase

--- a/lib/octo_merge/pull_request.rb
+++ b/lib/octo_merge/pull_request.rb
@@ -21,8 +21,12 @@ module OctoMerge
       github_api_result.head.repo.ssh_url
     end
 
-    def branch
+    def remote_branch
       github_api_result.head.ref
+    end
+
+    def number_branch
+      "pull/#{number}"
     end
 
     def title

--- a/lib/octo_merge/strategy/base.rb
+++ b/lib/octo_merge/strategy/base.rb
@@ -26,6 +26,21 @@ module OctoMerge
         @git ||= Git.new(working_directory)
       end
 
+      # Fetch the read-only branch for the corresponding pull request and
+      # create a local branch to rebase the current master on.
+      #
+      # Read more: [Checking out pull requests locally](https://help.github.com/articles/checking-out-pull-requests-locally/)
+      def fetch(pull_request)
+        git.fetch "#{upstream} #{pull_request.number_branch}/head:#{pull_request.number_branch} --force"
+      end
+
+      def fetch_master
+        git.checkout(master)
+        git.fetch(upstream)
+        git.reset_hard("#{upstream}/#{master}")
+      end
+
+
       def upstream
         :upstream
       end

--- a/lib/octo_merge/strategy/merge_with_rebase.rb
+++ b/lib/octo_merge/strategy/merge_with_rebase.rb
@@ -2,18 +2,27 @@ module OctoMerge
   module Strategy
     class MergeWithRebase < Base
       def run
-        git.checkout(master)
-        git.fetch(upstream)
-        git.reset_hard("#{upstream}/#{master}")
+        fetch_master
 
         pull_requests.each do |pull_request|
-          git.remote_add("#{pull_request.remote} #{pull_request.remote_url}")
-          git.fetch(pull_request.remote)
-          git.checkout(pull_request.branch)
+          fetch(pull_request)
+
+          git.checkout(pull_request.number_branch)
           git.rebase(master)
+
           git.checkout(master)
-          git.merge_no_ff(pull_request.branch)
+          merge(pull_request)
+
+          git.delete_branch(pull_request.number_branch)
         end
+      end
+
+      private
+
+      def merge(pull_request)
+        message = "Merge branch '#{pull_request.remote_branch}'"
+
+        git.merge_no_ff("-m \"#{message}\" #{pull_request.number_branch}")
       end
     end
   end

--- a/lib/octo_merge/strategy/merge_with_rebase_and_message.rb
+++ b/lib/octo_merge/strategy/merge_with_rebase_and_message.rb
@@ -4,19 +4,20 @@ module OctoMerge
   module Strategy
     class MergeWithRebaseAndMessage < Base
       def run
-        git.checkout(master)
-        git.fetch(upstream)
-        git.reset_hard("#{upstream}/#{master}")
+        fetch_master
 
         pull_requests.each do |pull_request|
-          git.remote_add("#{pull_request.remote} #{pull_request.remote_url}")
-          git.fetch(pull_request.remote)
-          git.checkout(pull_request.branch)
+          fetch(pull_request)
+
+          git.checkout(pull_request.number_branch)
           git.rebase(master)
+
           git.checkout(master)
-          git.merge_no_ff(pull_request.branch)
+          git.merge_no_ff(pull_request.number_branch)
 
           add_merge_message(pull_request)
+
+          git.delete_branch(pull_request.number_branch)
         end
       end
 
@@ -66,7 +67,7 @@ module OctoMerge
 
         def body
           sanitize <<-BODY
-Merge branch '#{pull_request.branch}'
+Merge branch '#{pull_request.remote_branch}'
 
 Resolves and closes: #{pull_request.url}
 

--- a/lib/octo_merge/strategy/merge_without_rebase.rb
+++ b/lib/octo_merge/strategy/merge_without_rebase.rb
@@ -2,15 +2,22 @@ module OctoMerge
   module Strategy
     class MergeWithoutRebase < Base
       def run
-        git.checkout(master)
-        git.fetch(upstream)
-        git.reset_hard("#{upstream}/#{master}")
+        fetch_master
 
         pull_requests.each do |pull_request|
-          git.remote_add("#{pull_request.remote} #{pull_request.remote_url}")
-          git.fetch(pull_request.remote)
-          git.merge_no_ff("#{pull_request.remote}/#{pull_request.branch}")
+          fetch(pull_request)
+          merge(pull_request)
+
+          git.delete_branch(pull_request.number_branch)
         end
+      end
+
+      private
+
+      def merge(pull_request)
+        message = "Merge remote branch '#{pull_request.remote}/#{pull_request.remote_branch}'"
+
+        git.merge_no_ff("-m \"#{message}\" #{pull_request.number_branch}")
       end
     end
   end

--- a/lib/octo_merge/strategy/rebase.rb
+++ b/lib/octo_merge/strategy/rebase.rb
@@ -2,17 +2,18 @@ module OctoMerge
   module Strategy
     class Rebase < Base
       def run
-        git.checkout(master)
-        git.fetch(upstream)
-        git.reset_hard("#{upstream}/#{master}")
+        fetch_master
 
         pull_requests.each do |pull_request|
-          git.remote_add("#{pull_request.remote} #{pull_request.remote_url}")
-          git.fetch(pull_request.remote)
-          git.checkout(pull_request.branch)
+          fetch(pull_request)
+
+          git.checkout(pull_request.number_branch)
           git.rebase(master)
+
           git.checkout(master)
-          git.rebase("#{pull_request.branch}")
+          git.rebase("#{pull_request.number_branch}")
+
+          git.delete_branch(pull_request.number_branch)
         end
       end
     end

--- a/spec/octo_merge/pull_request_spec.rb
+++ b/spec/octo_merge/pull_request_spec.rb
@@ -10,7 +10,8 @@ describe OctoMerge::PullRequest do
   its(:url) { is_expected.to eq("https://github.com/rails/rails/pull/23") }
   its(:remote) { is_expected.to eq("jackdempsey") }
   its(:remote_url) { is_expected.to eq("git@github.com:jackdempsey/rails.git") }
-  its(:branch) { is_expected.to eq("fix_requires") }
+  its(:remote_branch) { is_expected.to eq("fix_requires") }
+  its(:number_branch) { is_expected.to eq("pull/23") }
   its(:number) { is_expected.to eq("23") }
   its(:title) { is_expected.to eq("Fix requires for inflection related files") }
   its(:body) { is_expected.to start_with("Documented an issue") }

--- a/spec/octo_merge/strategy/merge_without_rebase_spec.rb
+++ b/spec/octo_merge/strategy/merge_without_rebase_spec.rb
@@ -5,15 +5,14 @@ describe OctoMerge::Strategy::MergeWithoutRebase do
 
   let(:expected_history) do
 <<-'EXPECTED_HISTORY'.strip
-*   Merge remote-tracking branch 'bob/sunglasses'
+*   Merge remote branch 'bob/sunglasses'
 |\
 | * Adds sunglasses
-* |   Merge remote-tracking branch 'alice/cowboy_hat'
+* |   Merge remote branch 'alice/cowboy_hat'
 |\ \
 | * | Adds cowboy_hat
-* | | Adds piercing
 | |/
-|/|
+* | Adds piercing
 * | Adds tattoo
 |/
 * Adds earrrings

--- a/spec/support/setup_example_repos.rb
+++ b/spec/support/setup_example_repos.rb
@@ -4,8 +4,6 @@ module SetupExampleRepos
       subject(:history) { mallory.history }
 
       let(:upstream) { SimpleGit.new(name: "upstream") }
-      let(:alice) { SimpleGit.new(name: "alice") }
-      let(:bob) { SimpleGit.new(name: "bob") }
       let(:mallory) { SimpleGit.new(name: "mallory") }
 
       let(:working_directory) { mallory.path }
@@ -13,8 +11,8 @@ module SetupExampleRepos
         instance_double(
           OctoMerge::PullRequest,
           remote: "alice",
-          remote_url: "../alice",
-          branch: "cowboy_hat",
+          remote_branch: "cowboy_hat",
+          number_branch: "pull/23",
           url: "example.com/23",
           title: "Adds cowboy hat",
           body: ""
@@ -24,8 +22,8 @@ module SetupExampleRepos
         instance_double(
           OctoMerge::PullRequest,
           remote: "bob",
-          remote_url: "../bob",
-          branch: "sunglasses",
+          remote_branch: "sunglasses",
+          number_branch: "pull/42",
           url: "example.com/42",
           title: "Adds sunglasses",
           body: "## Lorem ipsum\n\ndolor sit amet!"
@@ -47,29 +45,23 @@ module SetupExampleRepos
     SimpleGit.clear!
 
     upstream.create
-    alice.create
-    bob.create
-    mallory.create
-
-    alice.add_remote("upstream")
-    bob.add_remote("upstream")
-    mallory.add_remote("upstream")
-
-    # First commit
     upstream.add_item("earrrings")
+    upstream.checkout_branch("original-master")
 
-    alice.reset("upstream", "master")
-    alice.checkout_branch("cowboy_hat")
-    alice.add_item("cowboy_hat")
+    mallory.create
+    mallory.add_remote("upstream")
+    mallory.reset("upstream", "master")
 
-    # Second commit
+    upstream.checkout("master")
     upstream.add_item("tattoo")
-
-    bob.reset("upstream", "master")
-    bob.checkout_branch("sunglasses")
-    bob.add_item("sunglasses")
-
-    # Third commit
     upstream.add_item("piercing")
+
+    upstream.checkout("original-master")
+    upstream.checkout_branch("pull/23/head")
+    upstream.add_item("cowboy_hat")
+
+    upstream.checkout("original-master")
+    upstream.checkout_branch("pull/42/head")
+    upstream.add_item("sunglasses")
   end
 end


### PR DESCRIPTION
Instead of adding a remote and pull the branch from this remote, another
strategy is applied to get the changes into the master branch:

> Fetch the read-only branch for the corresponding pull request and
> create a local branch to rebase the current master on.
## Links
- [Checking out pull requests locally](https://help.github.com/articles/checking-out-pull-requests-locally/)
