### PR TITLE
Renames to "octo-merge"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Use at your own risk!
 
 # OctoMerge
 
-`octo_merge` is a simple command line tool to merge GitHub pull requests using different strategies.
+`octo-merge` is a simple command line tool to merge GitHub pull requests using different strategies.
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'octo_merge'
+gem 'octo-merge'
 ```
 
 And then execute:
@@ -23,7 +23,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install octo_merge
+    $ gem install octo-merge
 
 ## Examples
 
@@ -107,7 +107,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/Deradon/octo_merge. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/Deradon/octo-merge. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 
 ## License

--- a/octo_merge.gemspec
+++ b/octo_merge.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'octo_merge/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "octo_merge"
+  spec.name          = "octo-merge"
   spec.version       = OctoMerge::VERSION
   spec.authors       = ["Patrick Helm"]
   spec.email         = ["me@patrick-helm.de"]
@@ -13,16 +13,8 @@ Gem::Specification.new do |spec|
   spec.description   = %q{
   octo_merge is a simple command line tool to merge GitHub pull requests using different strategies
   }
-  spec.homepage      = "https://github.com/Deradon/octo_merge"
+  spec.homepage      = "https://github.com/Deradon/octo-merge"
   spec.license       = "MIT"
-
-  # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
-  # delete this section to allow pushing this gem to any host.
-  # if spec.respond_to?(:metadata)
-  #   spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  # else
-  #   raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
-  # end
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"


### PR DESCRIPTION
## Why?

The binary was always called "octo-merge" but installing this gem
required: `gem install octo_merge`. Now you have to use the same name to
install and run this tool: `gem install octo-merge && octo-merge`.
